### PR TITLE
Add support for halls position in the venue

### DIFF
--- a/lib/location.py
+++ b/lib/location.py
@@ -28,7 +28,6 @@ def normalize_table_name(table):
 def add_coordinates(seatmap, cursor):
     halls = {}
     tables = {}
-    halls_positions = {}
     for seat in seatmap:
         if not is_valid_seat(seat):
             if is_hall_position(seat):

--- a/lib/location.py
+++ b/lib/location.py
@@ -12,6 +12,8 @@ def even(x):
 def is_valid_seat(seat):
     return all (key in seat for key in ("row", "seat", "x1", "x2", "y1", "y2"))
 
+def is_hall_position(seat):
+    return all (key in seat for key in ("hall", "type", "x", "y"))
 
 def get_hall_from_table_name(table):
     return re.search('([A-Za-z]+)[0-9]+', table).group(1)
@@ -26,11 +28,12 @@ def normalize_table_name(table):
 def add_coordinates(seatmap, cursor):
     halls = {}
     tables = {}
-    # Currently we don't use the "hall" property of the seatmap but calculate
-    # our own grouping based on the initial non-numeric characters in the table
-    # name. That way we work around the human naming of halls.
+    halls_positions = {}
     for seat in seatmap:
         if not is_valid_seat(seat):
+            if is_hall_position(seat):
+                hall = seat['hall']
+                cursor.execute("INSERT INTO hall_positions VALUES (?,?,?)", (seat['hall'], seat['x'], seat['y']))
             continue
         table = normalize_table_name(seat['row'])
         logging.debug("Normalized table name %s to %s", seat['row'], table)

--- a/lib/location.py
+++ b/lib/location.py
@@ -115,18 +115,16 @@ def add_coordinates(seatmap, cursor):
 def switch_locations(t, n):
     locations = []
 
-    # TODO(bluecmd): This might need a closer look, talk to nlindblad
-    padding = 2
     if t.horizontal:
         for i in range(1, 2 * n, 2):
             x = t.x_start + (t.width / n) / 2 * i
             y = t.y_start - t.height / 2
-            locations.append((even(x), even(y)))
+            locations.append((x,y))
     else:
         for i in range(1, 2 * n, 2):
             x = t.x_start - t.height / 2
-            y = t.y_start + (t.width / n) / 2 * i - padding
-            locations.append((even(x), even(y)))
+            y = t.y_start + (t.width / n) / 2 * i
+            locations.append((x,y))
 
     return locations
 

--- a/lib/tables.py
+++ b/lib/tables.py
@@ -101,6 +101,12 @@ def create(conn):
     y INTEGER,
     table_name TEXT)''')
 
+    # Hall positions
+    c.execute('''CREATE TABLE hall_positions(
+    name TEXT,
+    x INTEGER,
+    y INTEGER)''')
+
     # Meta data
     c.execute('''CREATE TABLE meta_data(name TEXT, value TEXT)''')
 


### PR DESCRIPTION
This PR adds support for reading a hall position from seatmap.json and adding it to ipplan.

New ipplan table : 
`hall_positions (name, x, y)`

Expected seatmap.json format (as an item of the root "array" defined in the file):
```
{
    "hall": "Operations Center",
    "type": "hall_position",
    "x": 2,
    "y": 0
}
```